### PR TITLE
Fix KeyError from attempting to provide ssh key too early

### DIFF
--- a/jujubigdata/relations.py
+++ b/jujubigdata/relations.py
@@ -10,6 +10,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # Apache License for more details.
 
+import pwd
 import json
 
 from charmhelpers.core import hookenv
@@ -111,9 +112,15 @@ class SSHRelation(Relation):
 
     def provide(self, remote_service, all_ready):
         data = super(SSHRelation, self).provide(remote_service, all_ready)
-        data.update({
-            'ssh-key': utils.get_ssh_key(self.ssh_user),
-        })
+        try:
+            pwd.getpwnam(self.ssh_user)
+        except KeyError:
+            hookenv.log('Cannot provide SSH key yet, user not available: %s' % self.ssh_user)
+            return data
+        else:
+            data.update({
+                'ssh-key': utils.get_ssh_key(self.ssh_user),
+            })
         return data
 
 

--- a/jujubigdata/relations.py
+++ b/jujubigdata/relations.py
@@ -116,7 +116,6 @@ class SSHRelation(Relation):
             pwd.getpwnam(self.ssh_user)
         except KeyError:
             hookenv.log('Cannot provide SSH key yet, user not available: %s' % self.ssh_user)
-            return data
         else:
             data.update({
                 'ssh-key': utils.get_ssh_key(self.ssh_user),


### PR DESCRIPTION
Got a KeyError during a deployment that seems to be due to the Hadoop base install being delayed or blocked due to resource fetching issues and SSHRelation still attempting to send the keys over: http://pastebin.ubuntu.com/11916937/
