### PR TITLE
fix to allow jujubigdata to validate live datanodes 

### DIFF
--- a/jujubigdata/utils.py
+++ b/jujubigdata/utils.py
@@ -443,7 +443,7 @@ def wait_for_hdfs(timeout):
     while time.time() - start < timeout:
         try:
             output = run_as('hdfs', 'hdfs', 'dfsadmin', '-report', capture_output=True)
-            if 'Datanodes available' in output:
+            if 'Datanodes available' or 'Live datanodes' in output:
                 return True
         except CalledProcessError as e:
             output = e.output  # probably a "connection refused"; wait and try again

--- a/jujubigdata/utils.py
+++ b/jujubigdata/utils.py
@@ -443,7 +443,7 @@ def wait_for_hdfs(timeout):
     while time.time() - start < timeout:
         try:
             output = run_as('hdfs', 'hdfs', 'dfsadmin', '-report', capture_output=True)
-            if 'Datanodes available' or 'Live datanodes' in output:
+            if 'Datanodes available' in output or 'Live datanodes' in output:
                 return True
         except CalledProcessError as e:
             output = e.output  # probably a "connection refused"; wait and try again


### PR DESCRIPTION
2.4.1 returns substring: Datanodes available
2.7.1. makes this: Live datanodes

Validation of live data nodes should be moved to the charm itself to be handled within the relation
