### PR TITLE
Cleanups for yarn-master

### DIFF
--- a/jujubigdata/handlers.py
+++ b/jujubigdata/handlers.py
@@ -385,9 +385,8 @@ class YARN(object):
         self._jobhistory_daemon('stop', 'historyserver')
 
     def start_jobhistory(self):
-        if utils.jps('JobHistoryServer'):
-            self._jobhistory_daemon('stop', 'historyserver')
-        self._jobhistory_daemon('start', 'historyserver')
+        if not utils.jps('JobHistoryServer'):
+            self._jobhistory_daemon('start', 'historyserver')
 
     def stop_nodemanager(self):
         self._yarn_daemon('stop', 'nodemanager')
@@ -478,6 +477,7 @@ class YARN(object):
 
     def register_slaves(self):
         self.hadoop_base.register_slaves('nodemanager')
+        self.hadoop_base.run('mapred', 'bin/yarn', 'rmadmin', '-refreshNodes')
 
     def _yarn_daemon(self, command, service):
         self.hadoop_base.run('yarn', 'sbin/yarn-daemon.sh',

--- a/jujubigdata/handlers.py
+++ b/jujubigdata/handlers.py
@@ -359,6 +359,7 @@ class HDFS(object):
 
     def register_slaves(self):
         self.hadoop_base.register_slaves('datanode')
+        self.hadoop_base.run('hdfs', 'bin/hdfs', 'dfsadmin', '-refreshNodes')
 
     def _hadoop_daemon(self, command, service):
         self.hadoop_base.run('hdfs', 'sbin/hadoop-daemon.sh',


### PR DESCRIPTION
Skip restarting JobHistoryServer and call rmadmin -refreshNodes to update slave list
