### PR TITLE
Enable LZO resource installation in HadoopBase (if available)

### DIFF
--- a/jujubigdata/handlers.py
+++ b/jujubigdata/handlers.py
@@ -151,7 +151,12 @@ class HadoopBase(object):
                                   skip_top_level=True)
 
         # Install our lzo compression codec if it's defined in resources.yaml
+        mirror = hookenv.config('resources_mirror')
         try:
+            # resource_path throws a KeyError if hadoop-lzo-arch is not defined
+            jujuresources.resource_path('hadoop-lzo-%s' % self.cpu_arch)
+            jujuresources.fetch('hadoop-lzo-%s' % self.cpu_arch,
+                                mirror_url=mirror)
             jujuresources.install('hadoop-lzo-%s' % self.cpu_arch,
                                   destination=self.dist_config.path('hadoop'),
                                   skip_top_level=False)

--- a/jujubigdata/handlers.py
+++ b/jujubigdata/handlers.py
@@ -30,6 +30,9 @@ class HadoopBase(object):
         self.dist_config = dist_config
         self.charm_config = hookenv.config()
         self.cpu_arch = host.cpu_arch()
+        self.client_spec = {
+            'hadoop': self.dist_config.hadoop_version,
+        }
 
         # dist_config will have simple validation done on primary keys in the
         # dist.yaml, but we need to ensure deeper values are present.
@@ -42,15 +45,25 @@ class HadoopBase(object):
                 'ies' if len(missing_dirs) > 1 else 'y',
                 ', '.join(missing_dirs)))
 
-        self.client_spec = {
-            'hadoop': self.dist_config.hadoop_version,
-        }
+        # Build a list of hadoop resources needed from resources.yaml
+        hadoop_resources = []
         hadoop_version = self.dist_config.hadoop_version
         try:
             jujuresources.resource_path('hadoop-%s-%s' % (hadoop_version, self.cpu_arch))
-            self.verify_conditional_resources = utils.verify_resources('hadoop-%s-%s' % (hadoop_version, self.cpu_arch))
+            hadoop_resources.append('hadoop-%s-%s' % (hadoop_version, self.cpu_arch))
         except KeyError:
-            self.verify_conditional_resources = utils.verify_resources('hadoop-%s' % (self.cpu_arch))
+            hadoop_resources.append('hadoop-%s' % (self.cpu_arch))
+
+        # LZO compression for hadoop is distributed separately. Add it to the
+        # list of reqs if defined in resources.yaml
+        try:
+            jujuresources.resource_path('hadoop-lzo-%s' % self.cpu_arch)
+            hadoop_resources.append('hadoop-lzo-%s' % (self.cpu_arch))
+        except KeyError:
+            pass
+
+        # Verify and fetch the required hadoop resources
+        self.verify_conditional_resources = utils.verify_resources(*hadoop_resources)
 
     def spec(self):
         """
@@ -151,18 +164,15 @@ class HadoopBase(object):
                                   skip_top_level=True)
 
         # Install our lzo compression codec if it's defined in resources.yaml
-        mirror = hookenv.config('resources_mirror')
         try:
-            # resource_path throws a KeyError if hadoop-lzo-arch is not defined
-            jujuresources.resource_path('hadoop-lzo-%s' % self.cpu_arch)
-            jujuresources.fetch('hadoop-lzo-%s' % self.cpu_arch,
-                                mirror_url=mirror)
             jujuresources.install('hadoop-lzo-%s' % self.cpu_arch,
                                   destination=self.dist_config.path('hadoop'),
                                   skip_top_level=False)
             unitdata.kv().set('hadoop.lzo.installed', True)
         except KeyError:
-            hookenv.log("hadoop-lzo was not installed. LZO compression will not be available.")
+            msg = ("The hadoop-lzo-%s resource was not found."
+                   "LZO compression will not be available." % self.cpu_arch)
+            hookenv.log(msg)
 
     def setup_hadoop_config(self):
         # copy default config into alternate dir


### PR DESCRIPTION
My last PR didn't work.  I assumed jujuresources.install would fetch missing resources, but it does not (at least not for url resources).  This causes self.verify to fail since the resource hasn't been fetched:

https://github.com/juju-solutions/jujuresources/blob/master/jujuresources/backend.py#L126

This new PR hacky hacks like we did for hadoop-%s-%s... That is, it lets jr.resource_path throw a keyerror if hadoop-lzo-$arch is not defined in resources.yaml.  If it is a valid resource key, we proceed with fetch, followed by install.

Thoughts welcomed, especially from Cory since I'm pretty sure he doesn't like using jr.resource_path like this.  Another alternative would be to change jr.install so it does, in fact, fetch missing resources during install.
