### PR TITLE
python3 fix - unicode/strip

### DIFF
--- a/jujubigdata/utils.py
+++ b/jujubigdata/utils.py
@@ -286,7 +286,7 @@ def jps(name):
         output = check_output(['sudo', 'pgrep', '-f', pat]).decode('utf8')
     except CalledProcessError:
         return []
-    return filter(None, map(str.decode('utf8').strip, output.split('\n')))
+    return filter(None, output.strip().splitlines()
 
 
 class TimeoutError(Exception):

--- a/jujubigdata/utils.py
+++ b/jujubigdata/utils.py
@@ -286,7 +286,7 @@ def jps(name):
         output = check_output(['sudo', 'pgrep', '-f', pat]).decode('utf8')
     except CalledProcessError:
         return []
-    return filter(None, map(str.decode('utf8').strip, output.split('\n')))
+    return filter(None, output.strip().splitlines())
 
 
 class TimeoutError(Exception):

--- a/jujubigdata/utils.py
+++ b/jujubigdata/utils.py
@@ -286,7 +286,7 @@ def jps(name):
         output = check_output(['sudo', 'pgrep', '-f', pat]).decode('utf8')
     except CalledProcessError:
         return []
-    return filter(None, map(str.strip, output.split('\n')))
+    return filter(None, map(str.decode('utf8').strip, output.split('\n')))
 
 
 class TimeoutError(Exception):


### PR DESCRIPTION
Fix for the following:

File "/usr/local/lib/python2.7/dist-packages/jujubigdata/utils.py", line 289, in jps
return filter(None, map(str.strip, output.split('\n')))
TypeError: descriptor 'strip' requires a 'str' object but received a 'unicode'

Fixed as was done in PR#26
