### PR TITLE
Added get_ip_for_network_interface helper.

### DIFF
--- a/jujubigdata/utils.py
+++ b/jujubigdata/utils.py
@@ -16,6 +16,8 @@ import time
 import yaml
 import socket
 import subprocess
+import ipaddress
+import netifaces
 from contextlib import contextmanager
 from subprocess import check_call, check_output, CalledProcessError, Popen
 from xml.etree import ElementTree as ET
@@ -28,6 +30,10 @@ from charmhelpers.core import unitdata
 from charmhelpers.core import hookenv
 from charmhelpers.core import host
 from charmhelpers import fetch
+
+
+class BigDataError(Exception):
+    pass
 
 
 class DistConfig(object):
@@ -630,3 +636,68 @@ def spec_matches(local_spec, remote_spec):
         if v != remote_spec.get(k):
             return False
     return True
+
+
+def get_ip_for_interface(network_interface):
+    """
+    Helper to return the ip address of this machine on a specific
+    interface.
+
+    @param str network_interface: either the name of the
+    interface, or a CIDR range, in which we expect the interface's
+    ip to fall. Also accepts 0.0.0.0 (and variants, like 0/0) as a
+    special case, which will simply return what you passed in.
+
+    """
+    if network_interface.startswith('0') or network_interface == '::':
+        # Allow users to reset the charm to listening on any
+        # interface.  Allow operators to specify this however they
+        # wish (0.0.0.0, ::, 0/0, etc.).
+        return network_interface
+
+    # Is this a CIDR range, or an interface name?
+    is_cidr = len(network_interface.split(".")) == 4 or len(
+        network_interface.split(":")) == 8
+
+    if is_cidr:
+        interfaces = netifaces.interfaces()
+        for interface in interfaces:
+            for ip_version in netifaces.AF_INET, netifaces.AF_INET6:
+                try:
+                    ip = netifaces.ifaddresses(
+                        interface)[ip_version][0]['addr']
+                except KeyError:
+                    continue
+
+                if ip.startswith('fe80'):
+                    # ipaddress doesn't consider fe80::... to be an ip
+                    # address, even though interfaces on physical
+                    # hardware will list this as their ipv6 ip. Just
+                    # skip over this issue for now.
+                    continue
+
+                # Check to see if the ip address is in the
+                # range. Include a rather silly hack to make ipaddress
+                # happy with the unicode string it expects in both
+                # Python 2 and 3. (TODO: import unicode_literals from
+                # __future__, and verify that it doesn't break other
+                # things in this module.)
+                if ipaddress.ip_address(
+                        ip.encode('utf-8').decode('utf-8')
+                ) in ipaddress.ip_network(
+                    network_interface.encode('utf-8').decode('utf-8')
+                ):
+                    return ip
+
+        raise BigDataError(
+            u"This machine has no interfaces in CIDR range {}".format(
+                network_interface))
+    else:
+        try:
+            ip = netifaces.ifaddresses(network_interface)[netifaces.AF_INET][0]['addr']
+        except ValueError:
+            raise BigDataError(
+                u"This machine does not have an interface '{}'".format(
+                    network_interface))
+        return ip
+

--- a/jujubigdata/utils.py
+++ b/jujubigdata/utils.py
@@ -665,7 +665,7 @@ def get_ip_for_interface(network_interface, ip_version=4):
                     return str(interface['addr'])
                 except ValueError:
                     if not interface['addr'].startswith('fe80'):
-                        hookenv.log("Got an unexpected ValueError parsing {}. Continuing to search for a valid interface.".format(addr['addr']))
+                        hookenv.log("Got an unexpected ValueError parsing {}. Continuing to search for a valid interface.".format(interface['addr']))
                     continue
 
     # Kevin says this works

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ SETUP = {
         "jujuresources>=0.2.5",
         "setuptools-scm>=1.0.0,<2.0.0",  # needed by path.py (see pypa/pip#410)
         "charms.templating.jinja2>=1.0.0,<2.0.0",
+        "netifaces==0.10.4"
     ],
     'packages': [
         "jujubigdata",

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -12,3 +12,5 @@ flake8
 PyYAML==3.10       # precise
 path.py>=7.0
 jujuresources>=0.2.5
+netifaces==0.10.4
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,11 +142,11 @@ class TestUtils(unittest.TestCase):
 
         # Uncomment and replace with your local ethernet or wireless
         # interface for extra testing/paranoia.
-        ip = utils.get_ip_for_interface('enp4s0')
-        self.assertEqual(ip, '192.168.1.238')
+        # ip = utils.get_ip_for_interface('enp4s0')
+        # self.assertEqual(ip, '192.168.1.238')
 
-        ip = utils.get_ip_for_interface('192.168.1.0/24')
-        self.assertEqual(ip, '192.168.1.238')
+        # ip = utils.get_ip_for_interface('192.168.1.0/24')
+        # self.assertEqual(ip, '192.168.1.238')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = lint, py27, py34, docs
+envlist = lint, py27, py34, py35, docs
 skipsdist = True
 
 [tox:travis]


### PR DESCRIPTION
Allows a charm to lookup the ip address of a named network interface, or
find a network interface that falls in a cidr range.

Added tests, and fixed things so that tox will actually run test_utils.py.

@juju-solutions/bigdata 
